### PR TITLE
Automatically manage engine versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+engine
 bin
 obj
 mods/*/*.dll

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "engine"]
-	path = engine
-	url = https://github.com/OpenRA/OpenRA/
-	branch = bleed

--- a/fetch-engine.sh
+++ b/fetch-engine.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Helper script used to check and update engine dependencies
+# This should not be called manually
+
+command -v curl >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires curl."; exit 1; }
+command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
+
+TEMPLATE_LAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
+TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
+
+# shellcheck source=mod.config
+. "${TEMPLATE_ROOT}/mod.config"
+
+CURRENT_ENGINE_VERSION=$(cat "${ENGINE_DIRECTORY}/VERSION" 2> /dev/null)
+
+if [ -f "${ENGINE_DIRECTORY}/VERSION" ] && [ "${CURRENT_ENGINE_VERSION}" = "${ENGINE_VERSION}" ]; then
+	exit 0
+fi
+
+if [ "${AUTOMATIC_ENGINE_MANAGEMENT}" = "True" ]; then
+	echo "OpenRA engine version ${ENGINE_VERSION} is required."
+
+	if [ -d "${ENGINE_DIRECTORY}" ]; then
+		if [ "${CURRENT_ENGINE_VERSION}" != "" ]; then
+			echo "Deleting engine version ${CURRENT_ENGINE_VERSION}."
+		else
+			echo "Deleting existing engine (unknown version)."
+		fi
+
+		rm -rf "${ENGINE_DIRECTORY}"
+	fi
+
+	echo "Downloading engine..."
+	curl -s -L -o "${AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME}" -O "${AUTOMATIC_ENGINE_SOURCE}" || exit 3
+
+	# Github zipballs package code with a top level directory named based on the refspec
+	# Extract to a temporary directory and then move the subdir to our target location
+	REFNAME=$(unzip -qql "${AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME}" | head -n1 | tr -s ' ' | cut -d' ' -f5-)
+
+	rm -rf "${AUTOMATIC_ENGINE_EXTRACT_DIRECTORY}"
+	mkdir "${AUTOMATIC_ENGINE_EXTRACT_DIRECTORY}"
+	unzip -qq -d "${AUTOMATIC_ENGINE_EXTRACT_DIRECTORY}" "${AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME}"
+	mv "${AUTOMATIC_ENGINE_EXTRACT_DIRECTORY}/${REFNAME}" "${ENGINE_DIRECTORY}"
+	rmdir "${AUTOMATIC_ENGINE_EXTRACT_DIRECTORY}"
+	rm "${AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME}"
+
+	echo "Compiling engine..."
+	cd "${ENGINE_DIRECTORY}" || exit 1
+	make version VERSION="${ENGINE_VERSION}"
+	exit 0
+fi
+
+echo "Automatic engine management is disabled."
+echo "Please manually update the engine to version ${ENGINE_VERSION}."
+exit 1
+

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -19,9 +19,15 @@ if %INCLUDE_DEFAULT_MODS% neq "True" goto start
 set MOD_SEARCH_PATHS=%MOD_SEARCH_PATHS%,./mods
 
 :start
-cd engine
+if not exist %ENGINE_DIRECTORY%\OpenRA.Game.exe goto noengine
+cd %ENGINE_DIRECTORY%
 
 :loop
 OpenRA.Server.exe Game.Mod=%MOD_ID% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.ExternalPort=%ExternalPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password%
-
 goto loop
+
+:noengine
+echo Required engine files not found.
+echo Run `make all` in the mod directory to fetch and build the required files, then try again.
+pause
+exit /b

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
-# example launch script, see https://github.com/OpenRA/OpenRA/wiki/Dedicated for details
-
 # Usage:
 #  $ ./launch-dedicated.sh # Launch a dedicated server with default settings
-#  $ Mod="d2k" ./launch-dedicated.sh # Launch a dedicated server with default settings but override the Mod
+#  $ Mod="<mod id>" ./launch-dedicated.sh # Launch a dedicated server with default settings but override the Mod
 #  Read the file to see which settings you can override
+
+set -e
+command -v make >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires make."; exit 1; }
+command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
+command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires mono."; exit 1; }
 
 TEMPLATE_LAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
 TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
+
+# shellcheck source=mod.config
 . "${TEMPLATE_ROOT}/mod.config"
 
 MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods"
@@ -23,7 +28,14 @@ ADVERTISE_ONLINE="${AdvertiseOnline:-"True"}"
 ENABLE_SINGLE_PLAYER="${EnableSingleplayer:-"False"}"
 PASSWORD="${Password:-""}"
 
-cd engine
+cd "${TEMPLATE_ROOT}"
+if [ ! -f "${ENGINE_DIRECTORY}/OpenRA.Game.exe" ]; then
+	echo "Required engine files not found."
+	echo "Run \`make\` in the mod directory to fetch and build the required files, then try again.";
+	exit 1
+fi
+
+cd "${ENGINE_DIRECTORY}"
 
 while true; do
      MOD_SEARCH_PATHS="${MOD_SEARCH_PATHS}" mono --debug OpenRA.Server.exe Game.Mod="${LAUNCH_MOD}" \

--- a/launch-game.cmd
+++ b/launch-game.cmd
@@ -8,11 +8,23 @@ if %INCLUDE_DEFAULT_MODS% neq "True" goto launch
 set MOD_SEARCH_PATHS=%MOD_SEARCH_PATHS%,./mods
 
 :launch
-cd engine
+set TEMPLATE_DIR=%CD%
+if not exist %ENGINE_DIRECTORY%\OpenRA.Game.exe goto noengine
+
+cd %ENGINE_DIRECTORY%
 OpenRA.Game.exe Game.Mod=%MOD_ID% Engine.LaunchPath="%TEMPLATE_LAUNCHER%" "Engine.ModSearchPaths=%MOD_SEARCH_PATHS%"  "%*"
-if %errorlevel% neq 0 goto crashdialog
-cd ..
+set ERROR=%errorlevel%
+cd %TEMPLATE_DIR%
+
+if ERROR neq 0 goto crashdialog
 exit /b
+
+:noengine
+echo Required engine files not found.
+echo Run `make all` in the mod directory to fetch and build the required files, then try again.
+pause
+exit /b
+
 :crashdialog
 echo ----------------------------------------
 echo OpenRA has encountered a fatal error.

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
+set -e
+command -v make >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires make."; exit 1; }
+command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
+command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires mono."; exit 1; }
+
 TEMPLATE_LAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
 TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
+
+# shellcheck source=mod.config
 . "${TEMPLATE_ROOT}/mod.config"
 
 MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods"
@@ -9,5 +16,12 @@ if [ "${INCLUDE_DEFAULT_MODS}" = "True" ]; then
 	MOD_SEARCH_PATHS="${TEMPLATE_PATHS},./mods"
 fi
 
-cd engine
-mono OpenRA.Game.exe Engine.LaunchPath="${TEMPLATE_LAUNCHER}" "Engine.ModSearchPaths=${MOD_SEARCH_PATHS}" Game.Mod=${MOD_ID} "$@"
+cd "${TEMPLATE_ROOT}"
+if [ ! -f "${ENGINE_DIRECTORY}/OpenRA.Game.exe" ]; then
+	echo "Required engine files not found."
+	echo "Run \`make\` in the mod directory to fetch and build the required files, then try again.";
+	exit 1
+fi
+
+cd "${ENGINE_DIRECTORY}"
+mono OpenRA.Game.exe Engine.LaunchPath="${TEMPLATE_LAUNCHER}" "Engine.ModSearchPaths=${MOD_SEARCH_PATHS}" Game.Mod="${MOD_ID}" "$@"

--- a/mod.config
+++ b/mod.config
@@ -1,7 +1,7 @@
 # The id of the mod to launch by default.  This must exist as a directory in the mods directory
 MOD_ID="example"
 
-ENGINE_VERSION="3e5c211"
+ENGINE_VERSION="f75115a"
 
 # Import the default OpenRA mods for use as external mod references
 # in your mod.yaml. Accepts values "True" or "False".

--- a/mod.config
+++ b/mod.config
@@ -1,8 +1,20 @@
 # The id of the mod to launch by default.  This must exist as a directory in the mods directory
 MOD_ID="example"
 
+ENGINE_VERSION="3e5c211"
+
 # Import the default OpenRA mods for use as external mod references
 # in your mod.yaml. Accepts values "True" or "False".
 # WARNING: This setting is provided to simplify early mod development
 # and must be disabled before installers can be generated
 INCLUDE_DEFAULT_MODS="False"
+
+# Automatically manage engine dependencies
+AUTOMATIC_ENGINE_MANAGEMENT="True"
+AUTOMATIC_ENGINE_SOURCE="https://github.com/OpenRA/OpenRA/archive/${ENGINE_VERSION}.zip"
+
+# Temporary file/directory names used when automatically downloading the engine
+AUTOMATIC_ENGINE_EXTRACT_DIRECTORY="./engine_temp"
+AUTOMATIC_ENGINE_TEMP_ARCHIVE_NAME="engine.zip"
+
+ENGINE_DIRECTORY="./engine"

--- a/mods/example/mod.yaml
+++ b/mods/example/mod.yaml
@@ -60,6 +60,8 @@ SpriteFormats: ShpTS
 
 SpriteSequenceFormat: DefaultSpriteSequence
 
+ModelSequenceFormat: PlaceholderModelSequence
+
 GameSpeeds:
 	default:
 		Name: Normal

--- a/utility.cmd
+++ b/utility.cmd
@@ -9,7 +9,9 @@ if %INCLUDE_DEFAULT_MODS% neq "True" goto start
 set MOD_SEARCH_PATHS=%MOD_SEARCH_PATHS%,./mods
 
 :start
-cd engine
+set TEMPLATE_DIR=%CD%
+if not exist %ENGINE_DIRECTORY%\OpenRA.Game.exe goto noengine
+cd %ENGINE_DIRECTORY%
 
 :loop
 echo.
@@ -20,10 +22,16 @@ echo Press enter to view a list of valid utility commands.
 echo.
 
 set /P command=Please enter a command: OpenRA.Utility.exe %MOD_ID% 
-if /I "%command%" EQU "--exit" (cd .. & exit /b)
+if /I "%command%" EQU "--exit" (cd %TEMPLATE_DIR% & exit /b)
 echo.
 echo ----------------------------------------
 echo.
 echo OpenRA.Utility.exe %MOD_ID% %command%
 call OpenRA.Utility.exe %MOD_ID% %command%
 goto loop
+
+:noengine
+echo Required engine files not found.
+echo Run `make all` in the mod directory to fetch and build the required files, then try again.
+pause
+exit /b

--- a/utility.sh
+++ b/utility.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 # Usage:
 #  $ ./utility.sh # Launch the OpenRA.Utility with the default mod
-#  $ Mod="d2k" ./launch-utility.sh # Launch a dedicated server with a specific mod
+#  $ Mod="<mod id>" ./launch-utility.sh # Launch the OpenRA.Utility with a specific mod
+
+set -e
+command -v make >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires make."; exit 1; }
+command -v python >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires python."; exit 1; }
+command -v mono >/dev/null 2>&1 || { echo >&2 "The OpenRA mod template requires mono."; exit 1; }
 
 TEMPLATE_LAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
 TEMPLATE_ROOT=$(dirname "${TEMPLATE_LAUNCHER}")
+
+# shellcheck source=mod.config
 . "${TEMPLATE_ROOT}/mod.config"
 
 MOD_SEARCH_PATHS="${TEMPLATE_ROOT}/mods"
@@ -14,5 +21,12 @@ fi
 
 LAUNCH_MOD="${Mod:-"${MOD_ID}"}"
 
-cd engine
+cd "${TEMPLATE_ROOT}"
+if [ ! -f "${ENGINE_DIRECTORY}/OpenRA.Game.exe" ]; then
+	echo "Required engine files not found."
+	echo "Run \`make\` in the mod directory to fetch and build the required files, then try again.";
+	exit 1
+fi
+
+cd "${ENGINE_DIRECTORY}"
 MOD_SEARCH_PATHS="${MOD_SEARCH_PATHS}" mono --debug OpenRA.Utility.exe "${LAUNCH_MOD}" "$@"


### PR DESCRIPTION
Closes #7.

I would like to get a second/third set of eyes on this before merging – especially the Linux/macOS scripts, which I have reworked from the first version to follow the more sensible approach of @abcdefg30's powershell scripts.